### PR TITLE
Add maxHeight parameter to GooglePlacesAutoCompleteTextFormField

### DIFF
--- a/lib/google_places_autocomplete_text_field.dart
+++ b/lib/google_places_autocomplete_text_field.dart
@@ -2,15 +2,13 @@ library google_places_autocomplete_text_field;
 
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
-import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
-import 'package:rxdart/rxdart.dart';
-
 import 'package:google_places_autocomplete_text_field/model/place_details.dart';
 import 'package:google_places_autocomplete_text_field/model/prediction.dart';
+import 'package:rxdart/rxdart.dart';
 
 class GooglePlacesAutoCompleteTextFormField extends StatefulWidget {
   final String? initialValue;
@@ -74,6 +72,9 @@ class GooglePlacesAutoCompleteTextFormField extends StatefulWidget {
   final TextStyle? predictionsStyle;
   final OverlayContainer? overlayContainer;
   final String? proxyURL;
+
+  /// The maximum height of the suggestions list
+  final double? maxHeight;
 
   const GooglePlacesAutoCompleteTextFormField({
     super.key,
@@ -140,6 +141,7 @@ class GooglePlacesAutoCompleteTextFormField extends StatefulWidget {
     this.mouseCursor,
     this.contextMenuBuilder,
     this.validator,
+    this.maxHeight,
   });
 
   @override
@@ -311,26 +313,31 @@ class _GooglePlacesAutoCompleteTextFormFieldState
   }
 
   Widget get _overlayChild {
-    return ListView.builder(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      itemCount: allPredictions.length,
-      itemBuilder: (BuildContext context, int index) => InkWell(
-        onTap: () {
-          if (index < allPredictions.length) {
-            widget.itmClick!(allPredictions[index]);
-            if (!widget.isLatLngRequired) return;
+    return Container(
+      constraints: BoxConstraints(
+        maxHeight: widget.maxHeight ?? 200,
+      ),
+      child: ListView.builder(
+        padding: EdgeInsets.zero,
+        shrinkWrap: true,
+        itemCount: allPredictions.length,
+        itemBuilder: (BuildContext context, int index) => InkWell(
+          onTap: () {
+            if (index < allPredictions.length) {
+              widget.itmClick!(allPredictions[index]);
+              if (!widget.isLatLngRequired) return;
 
-            getPlaceDetailsFromPlaceId(allPredictions[index]);
+              getPlaceDetailsFromPlaceId(allPredictions[index]);
 
-            removeOverlay();
-          }
-        },
-        child: Container(
-          padding: const EdgeInsets.all(10),
-          child: Text(
-            allPredictions[index].description!,
-            style: widget.predictionsStyle ?? widget.style,
+              removeOverlay();
+            }
+          },
+          child: Container(
+            padding: const EdgeInsets.all(10),
+            child: Text(
+              allPredictions[index].description!,
+              style: widget.predictionsStyle ?? widget.style,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Status

My PR is **READY**

## Description
This PR adds a new `maxHeight` parameter to the GooglePlacesAutoCompleteTextFormField widget, allowing users to customize the maximum height of the suggestions list. The changes include:
- Adding a `maxHeight` parameter to the GooglePlacesAutoCompleteTextFormField class
- Modifying the _overlayChild getter to use the provided maxHeight or default to 200

These modifications improve the flexibility of the widget by allowing users to control the maximum height of the suggestions list based on their specific UI requirements.


## Type of Change
1. Added `maxHeight` parameter to GooglePlacesAutoCompleteTextFormField
2. Updated _overlayChild getter to use the new maxHeight parameter

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
