### PR TITLE
fix: improve error handling for DioException in GooglePlacesApi methods

### DIFF
--- a/lib/src/data/google_places_api.dart
+++ b/lib/src/data/google_places_api.dart
@@ -51,6 +51,16 @@ class GooglePlacesApi {
       final subscriptionResponse =
           PlacesAutocompleteResponse.fromJson(response.data);
       return subscriptionResponse;
+    } on DioException catch (e) {
+      if (e.response != null) {
+        debugPrint(
+            'GooglePlacesApi.getSuggestionsForInput: DioException [${e.type}]: ${e.message}');
+        debugPrint('Response data: ${e.response?.data}');
+      } else {
+        debugPrint(
+            'GooglePlacesApi.getSuggestionsForInput: DioException [${e.type}]: ${e.message}');
+      }
+      return null;
     } catch (e) {
       debugPrint('GooglePlacesApi.getSuggestionsForInput: ${e.toString()}');
       return null;
@@ -81,6 +91,16 @@ class GooglePlacesApi {
       prediction.lng = placeDetails.result!.geometry!.location!.lng.toString();
 
       return prediction;
+    } on DioException catch (e) {
+      if (e.response != null) {
+        debugPrint(
+            'GooglePlacesApi.fetchCoordinatesForPrediction: DioException [${e.type}]: ${e.message}');
+        debugPrint('Response data: ${e.response?.data}');
+      } else {
+        debugPrint(
+            'GooglePlacesApi.fetchCoordinatesForPrediction: DioException [${e.type}]: ${e.message}');
+      }
+      return null;
     } catch (e) {
       debugPrint(
           'GooglePlacesApi.fetchCoordinatesForPrediction: ${e.toString()}');


### PR DESCRIPTION
## Title: 

Add Detailed Logging for DioExceptions in GooglePlacesApi

# Status

My PR is **READY**

## Description

This pull request addresses an issue with insufficient transparency in error handling. When an API request fails, the console currently logs generic exception information, but not the actual response body, which often contains valuable details for debugging.

The PR improves the logging of DioException by adding the response body to the debug console. This helps developers quickly understand the root cause of the issue, such as misconfigured API keys or disabled APIs.

issue https://github.com/julienandco/google_places_autocomplete_text_field/issues/31

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
