### PR TITLE
Fix #35 Unhandled Exception when dispose() is called before the `getLocation()` Future is returned

### DIFF
--- a/lib/src/widgets/google_places_autocomplete_text_field.dart
+++ b/lib/src/widgets/google_places_autocomplete_text_field.dart
@@ -330,6 +330,7 @@ class _GooglePlacesAutoCompleteTextFormFieldState
     if (text.isEmpty || text.length < widget.minInputLength) {
       allPredictions.clear();
       _overlayEntry?.remove();
+      _overlayEntry?.dispose();
       return;
     }
 
@@ -443,6 +444,11 @@ class _GooglePlacesAutoCompleteTextFormFieldState
 
   void removeOverlay() {
     allPredictions.clear();
+    try {
+      _overlayEntry?.remove();
+    } catch (_) {}
+
+    _overlayEntry?.dispose();
     _overlayEntry = _createOverlayEntry();
     Overlay.of(context).insert(_overlayEntry!);
     _overlayEntry!.markNeedsBuild();

--- a/lib/src/widgets/google_places_autocomplete_text_field.dart
+++ b/lib/src/widgets/google_places_autocomplete_text_field.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -217,11 +219,25 @@ class _GooglePlacesAutoCompleteTextFormFieldState
   final LayerLink _layerLink = LayerLink();
 
   late FocusNode _focus;
+  late StreamSubscription<String> subscription;
+  CancelableOperation? cancelableOperation;
+
+  @override
+  void dispose() {
+    subscription.cancel();
+    subject.close();
+    _focus.dispose();
+    if (cancelableOperation != null) {
+      cancelableOperation?.cancel();
+    }
+
+    super.dispose();
+  }
 
   @override
   void initState() {
     _api = GooglePlacesApi();
-    subject.stream
+    subscription = subject.stream
         .distinct()
         .debounceTime(Duration(milliseconds: widget.debounceTime))
         .listen(textChanged);
@@ -345,9 +361,15 @@ class _GooglePlacesAutoCompleteTextFormFieldState
         ?.call(predictionWithCoordinates);
   }
 
+  Future<dynamic> fromCancelable(Future<dynamic> future) async {
+    cancelableOperation =
+        CancelableOperation.fromFuture(future, onCancel: () {});
+    return cancelableOperation?.value;
+  }
+
   Future<void> textChanged(String text) async {
     final overlay = Overlay.of(context);
-    getLocation(text).then(
+    fromCancelable(getLocation(text)).then(
       (_) {
         try {
           _overlayEntry?.remove();


### PR DESCRIPTION
Fixes issue #35, an Unhandled Exception when dispose() is called before the `getLocation()` future has returned.

# Status

My PR is **READY**

## Description

The bug is trigger by typing in the text field, then switching to another page. The unhandled exception occurs when `dispose()` is called on this widget before the `getLocation()` future has completed.

I've implemented a `getLocation()` as a `CancelableOperation`, which allows the future to be canceled in the dispose() method.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
